### PR TITLE
Publicly expose class `MapEntry` to allow the use of mapEntries()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 0.0.3
 
-* Added SyncState.isInSync
+- Added SyncState.isInSync
+
+## 0.0.4
+
+- Publicly expose class `MapEntry` to allow the use of mapEntries()

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Documentation is mostly just [the API docs](https://www.javadoc.io/doc/org.autom
 <dependency>
   <groupId>org.automerge</groupId>
   <artifactId>automerge</artifactId>
-  <version>0.0.3</version>
+  <version>0.0.4</version>
 </dependency>
 ```
 
@@ -23,14 +23,14 @@ Documentation is mostly just [the API docs](https://www.javadoc.io/doc/org.autom
 
 ```kotlin
 dependencies {
-    implementation group: 'org.automerge', name: 'automerge', version: "0.0.3"
+    implementation group: 'org.automerge', name: 'automerge', version: "0.0.4"
 }
 ```
 
 ### Leiningen
 
 ```
-  :dependencies [[org.automerge/automerge "0.0.3"]]
+  :dependencies [[org.automerge/automerge "0.0.4"]]
 ```
 
 ## A quick example

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -101,7 +101,7 @@ publishing {
         register<MavenPublication>("automerge") {
             groupId = "org.automerge"
             artifactId = "androidnative"
-            version = "0.0.3"
+            version = "0.0.4"
             afterEvaluate {
                 from(components["release"])
             }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -72,7 +72,7 @@ spotless {
     }
 }
 
-project.version = "0.0.3"
+project.version = "0.0.4"
 
 repositories {
     mavenCentral()

--- a/lib/src/main/java/org/automerge/MapEntry.java
+++ b/lib/src/main/java/org/automerge/MapEntry.java
@@ -1,6 +1,6 @@
 package org.automerge;
 
-class MapEntry {
+public class MapEntry {
 	private String key;
 	private AmValue value;
 


### PR DESCRIPTION
Simple PR to allow the use of the `mapEntries()` method. Currently it fails with the error `Type Optional<Array<(out) MapEntry!>!>! is inaccessible in this context due to: public/*package*/ open class MapEntry defined in org.automerge in file MapEntry.class` because the `MapEntry` class is not public.