### PR TITLE
Make AmValue.Counter.getValue() return long

### DIFF
--- a/lib/src/main/java/org/automerge/AmValue.java
+++ b/lib/src/main/java/org/automerge/AmValue.java
@@ -104,13 +104,13 @@ public abstract class AmValue {
 	public static class Counter extends AmValue {
 		private org.automerge.Counter value;
 
-		public org.automerge.Counter getValue() {
-			return value;
+		public long getValue() {
+			return value.getValue();
 		}
 
 		@Override
 		public String toString() {
-			return "Counter [value=" + value + "]";
+			return "Counter [value=" + value.getValue() + "]";
 		}
 	}
 

--- a/lib/src/test/java/org/automerge/TestGet.java
+++ b/lib/src/test/java/org/automerge/TestGet.java
@@ -134,7 +134,7 @@ class TestGet {
 
 			@Override
 			public void check(AmValue value) {
-				Assertions.assertEquals(new Counter(1), ((AmValue.Counter) value).getValue());
+				Assertions.assertEquals(1, ((AmValue.Counter) value).getValue());
 			}
 		});
 		// Timestamp

--- a/lib/src/test/java/org/automerge/TestIncrement.java
+++ b/lib/src/test/java/org/automerge/TestIncrement.java
@@ -22,7 +22,7 @@ public final class TestIncrement {
 	public void testIncrementInMap() {
 		tx.set(ObjectId.ROOT, "key", new Counter(10));
 		tx.increment(ObjectId.ROOT, "key", 5);
-		Assertions.assertEquals(new Counter(15), ((AmValue.Counter) doc.get(ObjectId.ROOT, "key").get()).getValue());
+		Assertions.assertEquals(15, ((AmValue.Counter) doc.get(ObjectId.ROOT, "key").get()).getValue());
 	}
 
 	@Test
@@ -30,6 +30,6 @@ public final class TestIncrement {
 		ObjectId list = tx.set(ObjectId.ROOT, "list", ObjectType.LIST);
 		tx.insert(list, 0, new Counter(10));
 		tx.increment(list, 0, 5);
-		Assertions.assertEquals(new Counter(15), ((AmValue.Counter) doc.get(list, 0).get()).getValue());
+		Assertions.assertEquals(15, ((AmValue.Counter) doc.get(list, 0).get()).getValue());
 	}
 }

--- a/lib/src/test/java/org/automerge/TestInsert.java
+++ b/lib/src/test/java/org/automerge/TestInsert.java
@@ -64,7 +64,7 @@ public final class TestInsert {
 	@Test
 	public void testInsertCounterInList() {
 		tx.insert(list, 0, new Counter(10));
-		Assertions.assertEquals(new Counter(10), ((AmValue.Counter) doc.get(list, 0).get()).getValue());
+		Assertions.assertEquals(10, ((AmValue.Counter) doc.get(list, 0).get()).getValue());
 	}
 
 	@Test

--- a/lib/src/test/java/org/automerge/TestListItems.java
+++ b/lib/src/test/java/org/automerge/TestListItems.java
@@ -111,7 +111,7 @@ public class TestListItems {
 		Assertions.assertEquals(1.2, ((AmValue.F64) items[5]).getValue());
 		Assertions.assertEquals("somestring", ((AmValue.Str) items[6]).getValue());
 		Assertions.assertInstanceOf(AmValue.Null.class, items[7]);
-		Assertions.assertEquals(new Counter(10), ((AmValue.Counter) items[8]).getValue());
+		Assertions.assertEquals(10, ((AmValue.Counter) items[8]).getValue());
 		Assertions.assertEquals(map, ((AmValue.Map) items[9]).getId());
 		Assertions.assertEquals(subList, ((AmValue.List) items[10]).getId());
 		Assertions.assertEquals(text, ((AmValue.Text) items[11]).getId());

--- a/lib/src/test/java/org/automerge/TestMapEntries.java
+++ b/lib/src/test/java/org/automerge/TestMapEntries.java
@@ -101,7 +101,7 @@ class TestMapEntries {
 		Assertions.assertArrayEquals("bytes".getBytes(), ((AmValue.Bytes) bytesEntry.getValue()).getValue());
 
 		MapEntry counterEntry = entrysByKey.get("counter");
-		Assertions.assertEquals(new Counter(10), ((AmValue.Counter) counterEntry.getValue()).getValue());
+		Assertions.assertEquals(10, ((AmValue.Counter) counterEntry.getValue()).getValue());
 
 		MapEntry dateEntry = entrysByKey.get("date");
 		Assertions.assertEquals(dateValue, ((AmValue.Timestamp) dateEntry.getValue()).getValue());

--- a/lib/src/test/java/org/automerge/TestMarks.java
+++ b/lib/src/test/java/org/automerge/TestMarks.java
@@ -43,7 +43,7 @@ class TestMarks {
 
 		Mark counterMark = marks.get(2);
 		assertMark(counterMark, 1, 5, "counter",
-				value -> Assertions.assertEquals(((AmValue.Counter) value).getValue().getValue(), 5));
+				value -> Assertions.assertEquals(((AmValue.Counter) value).getValue(), 5));
 
 		Mark dateMark = marks.get(3);
 		assertMark(dateMark, 1, 5, "date",

--- a/lib/src/test/java/org/automerge/TestPatches.java
+++ b/lib/src/test/java/org/automerge/TestPatches.java
@@ -58,7 +58,7 @@ class TestPatches {
 		});
 
 		assertPutMap(patches.get(7), ObjectId.ROOT, emptyPath(), "counter", (AmValue value) -> {
-			Assertions.assertEquals(((AmValue.Counter) value).getValue().getValue(), 3);
+			Assertions.assertEquals(((AmValue.Counter) value).getValue(), 3);
 		});
 
 		assertPutMap(patches.get(8), ObjectId.ROOT, emptyPath(), "timestamp", (AmValue value) -> {
@@ -146,7 +146,7 @@ class TestPatches {
 		});
 
 		assertSetInList(patches.get(8), list, PathBuilder.root("list").build(), 7, (AmValue value) -> {
-			Assertions.assertEquals(((AmValue.Counter) value).getValue().getValue(), 3);
+			Assertions.assertEquals(((AmValue.Counter) value).getValue(), 3);
 		});
 
 		assertSetInList(patches.get(9), list, PathBuilder.root("list").build(), 8, (AmValue value) -> {
@@ -210,7 +210,7 @@ class TestPatches {
 		Assertions.assertArrayEquals(((AmValue.Bytes) values.get(4)).getValue(), "bytes".getBytes());
 		Assertions.assertEquals(((AmValue.Bool) values.get(5)).getValue(), true);
 		Assertions.assertInstanceOf(AmValue.Null.class, values.get(6));
-		Assertions.assertEquals(((AmValue.Counter) values.get(7)).getValue().getValue(), 3);
+		Assertions.assertEquals(((AmValue.Counter) values.get(7)).getValue(), 3);
 		Assertions.assertEquals(((AmValue.Timestamp) values.get(8)).getValue(), now);
 		Assertions.assertEquals(((AmValue.List) values.get(9)).getId(), innerList);
 		Assertions.assertEquals(((AmValue.Map) values.get(10)).getId(), map);

--- a/lib/src/test/java/org/automerge/TestSetList.java
+++ b/lib/src/test/java/org/automerge/TestSetList.java
@@ -72,7 +72,7 @@ public final class TestSetList {
 	@Test
 	public void testSetCounterInList() {
 		tx.set(list, 0, new Counter(10));
-		Assertions.assertEquals(new Counter(10), ((AmValue.Counter) doc.get(list, 0).get()).getValue());
+		Assertions.assertEquals(10, ((AmValue.Counter) doc.get(list, 0).get()).getValue());
 	}
 
 	@Test

--- a/lib/src/test/java/org/automerge/TestSplice.java
+++ b/lib/src/test/java/org/automerge/TestSplice.java
@@ -111,8 +111,8 @@ public final class TestSplice {
 	@Test
 	public void testSpliceCounter() {
 		testSplice2(NewValue.counter(1), NewValue.counter(2), (elem1, elem2) -> {
-			Assertions.assertEquals(new Counter(1), ((AmValue.Counter) elem1).getValue());
-			Assertions.assertEquals(new Counter(2), ((AmValue.Counter) elem2).getValue());
+			Assertions.assertEquals(1, ((AmValue.Counter) elem1).getValue());
+			Assertions.assertEquals(2, ((AmValue.Counter) elem2).getValue());
 		});
 	}
 }

--- a/lib/src/test/java/org/automerge/TestTransaction.java
+++ b/lib/src/test/java/org/automerge/TestTransaction.java
@@ -135,8 +135,7 @@ public final class TestTransaction {
 	@Test
 	public final void setCounterInMap() {
 		tx.set(ObjectId.ROOT, "counter", new Counter(10));
-		Assertions.assertEquals(new Counter(10),
-				((AmValue.Counter) doc.get(ObjectId.ROOT, "counter").get()).getValue());
+		Assertions.assertEquals(10, ((AmValue.Counter) doc.get(ObjectId.ROOT, "counter").get()).getValue());
 	}
 
 	@Test


### PR DESCRIPTION
Since `org.automerge.Counter` has package visibility, we are not able to call `org.automerge.Counter.getValue()` outside automerge module and for caller we have no need to know `org.automerge.Counter`, so let's make `AmValue.Counter.getValue()` return long instead.