### PR TITLE
Make PatchLog public

### DIFF
--- a/lib/src/main/java/org/automerge/PatchLog.java
+++ b/lib/src/main/java/org/automerge/PatchLog.java
@@ -5,7 +5,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import org.automerge.AutomergeSys.PatchLogPointer;
 
-class PatchLog {
+public class PatchLog {
 	private Optional<PatchLogPointer> pointer;
 
 	public PatchLog() {


### PR DESCRIPTION
In order to do things like

```
PatchLog patchLog = new PatchLog();
doc.receiveSyncMessage(syncState, patchLog,  message);
List<Patch> diff = doc.makePatches(patchLog);
...
```

it would be beneficial if the PatchLog class is public.