### PR TITLE
Add Read.getObjectType

### DIFF
--- a/lib/src/main/java/org/automerge/AutomergeSys.java
+++ b/lib/src/main/java/org/automerge/AutomergeSys.java
@@ -335,4 +335,8 @@ class AutomergeSys {
 
 	public static native long lookupCursorIndexInTx(TransactionPointer tx, ObjectId obj, Cursor cursor,
 			Optional<ChangeHash[]> heads);
+
+	public static native Optional<ObjectType> getObjectTypeInDoc(DocPointer doc, ObjectId obj);
+
+	public static native Optional<ObjectType> getObjectTypeInTx(TransactionPointer tx, ObjectId obj);
 }

--- a/lib/src/main/java/org/automerge/Document.java
+++ b/lib/src/main/java/org/automerge/Document.java
@@ -714,4 +714,13 @@ public class Document implements Read {
 			return AutomergeSys.lookupCursorIndexInDoc(this.pointer.get(), obj, cursor, Optional.of(heads));
 		}
 	}
+
+	@Override
+	public synchronized Optional<ObjectType> getObjectType(ObjectId obj) {
+		if (this.transactionPtr.isPresent()) {
+			return AutomergeSys.getObjectTypeInTx(this.transactionPtr.get(), obj);
+		} else {
+			return AutomergeSys.getObjectTypeInDoc(this.pointer.get(), obj);
+		}
+	}
 }

--- a/lib/src/main/java/org/automerge/Read.java
+++ b/lib/src/main/java/org/automerge/Read.java
@@ -408,4 +408,15 @@ public interface Read {
 	 *             object
 	 */
 	public long lookupCursorIndex(ObjectId obj, Cursor cursor, ChangeHash[] heads);
+
+	/**
+	 * Get the object type of the object given by obj
+	 *
+	 * @param obj
+	 *            - The ID of the object to get the type of
+	 *
+	 * @return The type of the object or Optional.empty if the object does not exist
+	 *         in this document
+	 */
+	public Optional<ObjectType> getObjectType(ObjectId obj);
 }

--- a/lib/src/main/java/org/automerge/TransactionImpl.java
+++ b/lib/src/main/java/org/automerge/TransactionImpl.java
@@ -378,4 +378,9 @@ public class TransactionImpl implements Transaction {
 		return AutomergeSys.lookupCursorIndexInTx(this.pointer.get(), obj, cursor, Optional.of(heads));
 	}
 
+	@Override
+	public synchronized Optional<ObjectType> getObjectType(ObjectId obj) {
+		return AutomergeSys.getObjectTypeInTx(this.pointer.get(), obj);
+	}
+
 }

--- a/lib/src/test/java/org/automerge/TestGetObjType.java
+++ b/lib/src/test/java/org/automerge/TestGetObjType.java
@@ -1,0 +1,44 @@
+package org.automerge;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestGetObjType {
+
+	@Test
+	public void testGetObjType() {
+		Document doc = new Document();
+		ObjectId map;
+		ObjectId list;
+		ObjectId text;
+		try (Transaction tx = doc.startTransaction()) {
+			map = tx.set(ObjectId.ROOT, "map", ObjectType.MAP);
+			list = tx.set(ObjectId.ROOT, "list", ObjectType.LIST);
+			text = tx.set(ObjectId.ROOT, "text", ObjectType.TEXT);
+			tx.commit();
+		}
+
+		// make an object ID from a different document
+		Document otherDoc = new Document();
+		ObjectId missingObj;
+		try (Transaction tx = otherDoc.startTransaction()) {
+			missingObj = tx.set(ObjectId.ROOT, "other", ObjectType.MAP);
+			tx.commit();
+		}
+
+		Assertions.assertEquals(Optional.of(ObjectType.MAP), doc.getObjectType(map));
+		Assertions.assertEquals(Optional.of(ObjectType.LIST), doc.getObjectType(list));
+		Assertions.assertEquals(Optional.of(ObjectType.TEXT), doc.getObjectType(text));
+		Assertions.assertEquals(Optional.empty(), doc.getObjectType(missingObj));
+
+		// now the same tests but in a transaction
+		try (Transaction tx = doc.startTransaction()) {
+			Assertions.assertEquals(Optional.of(ObjectType.MAP), tx.getObjectType(map));
+			Assertions.assertEquals(Optional.of(ObjectType.LIST), tx.getObjectType(list));
+			Assertions.assertEquals(Optional.of(ObjectType.TEXT), tx.getObjectType(text));
+			Assertions.assertEquals(Optional.empty(), tx.getObjectType(missingObj));
+		}
+	}
+
+}

--- a/rust/src/cursor.rs
+++ b/rust/src/cursor.rs
@@ -58,8 +58,7 @@ impl Cursor {
             .map_err(errors::FromRaw::GetByteArray)?;
         let bytes =
             std::slice::from_raw_parts(arr.as_ptr() as *const u8, arr.size().unwrap() as usize);
-        let cursor: automerge::Cursor =
-            bytes.try_into().map_err(errors::FromRaw::Invalid)?;
+        let cursor: automerge::Cursor = bytes.try_into().map_err(errors::FromRaw::Invalid)?;
         Ok(Self(cursor))
     }
 }

--- a/rust/src/obj_type.rs
+++ b/rust/src/obj_type.rs
@@ -8,10 +8,16 @@ pub(crate) enum JavaObjType {
     Text,
 }
 
+pub(crate) const CLASSNAME: &str = am_classname!("ObjectType");
+
 // The ordinal of the various types in the `org.automerge.jni.ObjectType` enum
 const MAP_ORDINAL: i32 = 0;
 const LIST_ORDINAL: i32 = 1;
 const TEXT_ORDINAL: i32 = 2;
+
+const MAP_FIELD_NAME: &str = "MAP";
+const LIST_FIELD_NAME: &str = "LIST";
+const TEXT_FIELD_NAME: &str = "TEXT";
 
 impl JavaObjType {
     /// Convert a `jobject` referring to an instance of org.automerge.jni.ObjectType to a
@@ -41,6 +47,20 @@ impl JavaObjType {
             TEXT_ORDINAL => Ok(Self::Text),
             other => Err(FromJavaError::UnknownOrdinal(other)),
         }
+    }
+
+    /// Convert a `JavaObjType` to a `JOBject`
+    pub(crate) unsafe fn to_java_enum<'a>(
+        &'_ self,
+        env: jni::JNIEnv<'a>,
+    ) -> Result<JObject<'a>, jni::errors::Error> {
+        let field_name = match self {
+            Self::Map => MAP_FIELD_NAME,
+            Self::List => LIST_FIELD_NAME,
+            Self::Text => TEXT_FIELD_NAME,
+        };
+        let field = env.get_static_field(CLASSNAME, field_name, format!("L{};", CLASSNAME))?;
+        field.l()
     }
 }
 

--- a/rust/src/read_methods/get_object_type.rs
+++ b/rust/src/read_methods/get_object_type.rs
@@ -1,0 +1,26 @@
+use automerge_jni_macros::jni_fn;
+use jni::sys::jobject;
+
+use super::SomeReadPointer;
+
+#[no_mangle]
+#[jni_fn]
+pub unsafe extern "C" fn getObjectTypeInDoc(
+    env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+    doc_pointer: jni::sys::jobject,
+    obj_pointer: jni::sys::jobject,
+) -> jobject {
+    SomeReadPointer::doc(doc_pointer).get_object_type(env, obj_pointer)
+}
+
+#[no_mangle]
+#[jni_fn]
+pub unsafe extern "C" fn getObjectTypeInTx(
+    env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+    tx_pointer: jni::sys::jobject,
+    obj_pointer: jni::sys::jobject,
+) -> jobject {
+    SomeReadPointer::tx(tx_pointer).get_object_type(env, obj_pointer)
+}


### PR DESCRIPTION
Problem: sometimes you have an object ID but need to know what type of object the ID points at in order to determine what to do with it but there is no way of getting this information from automerge.

Solution: add Read.getObjectType which returns the type of the object ID, or `Optional.empty` if the object is not in the document.

Fixes #5 