### PR TITLE
Check for null object IDs

### DIFF
--- a/lib/src/test/java/org/automerge/TestDocument.java
+++ b/lib/src/test/java/org/automerge/TestDocument.java
@@ -63,4 +63,15 @@ public final class TestDocument {
 		Document doc = new Document();
 		doc.free();
 	}
+
+	@Test
+	public void testNullObjectIdThrows() {
+		// this test is actually a test for any path which uses an `ObjectId`
+		// as the code which throws the exception is in the rust implementation
+		// which converts the `ObjectId` into an internal rust type
+		Document doc = new Document();
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			doc.get(null, "key");
+		});
+	}
 }

--- a/lib/src/test/java/org/automerge/TestSplice.java
+++ b/lib/src/test/java/org/automerge/TestSplice.java
@@ -15,7 +15,6 @@ public final class TestSplice {
 	interface InsertedAssertions {
 		void assertInserted(Object elem1, Object elem2);
 	}
-
 	public TestSplice() {
 		super();
 	}

--- a/rust/src/transaction/delete.rs
+++ b/rust/src/transaction/delete.rs
@@ -5,7 +5,10 @@ use jni::{
     sys::{jlong, jobject},
 };
 
-use crate::{obj_id::JavaObjId, AUTOMERGE_EXCEPTION};
+use crate::{
+    obj_id::{obj_id_or_throw, JavaObjId},
+    AUTOMERGE_EXCEPTION,
+};
 
 use super::{do_tx_op, TransactionOp};
 
@@ -18,7 +21,7 @@ impl TransactionOp for DeleteOp {
     type Output = ();
 
     unsafe fn execute<T: Transactable>(self, env: jni::JNIEnv, tx: &mut T) -> Self::Output {
-        let obj = JavaObjId::from_raw(&env, self.obj).unwrap();
+        let obj = obj_id_or_throw!(&env, self.obj, ());
         match tx.delete(obj, self.key) {
             Ok(_) => {}
             Err(e) => {

--- a/rust/src/transaction/increment.rs
+++ b/rust/src/transaction/increment.rs
@@ -4,7 +4,10 @@ use jni::{
     sys::{jlong, jobject},
 };
 
-use crate::{obj_id::JavaObjId, AUTOMERGE_EXCEPTION};
+use crate::{
+    obj_id::{obj_id_or_throw, JavaObjId},
+    AUTOMERGE_EXCEPTION,
+};
 
 use super::{do_tx_op, TransactionOp};
 
@@ -22,7 +25,7 @@ impl TransactionOp for IncrementOp {
         env: jni::JNIEnv,
         tx: &mut T,
     ) -> Self::Output {
-        let obj = JavaObjId::from_raw(&env, self.obj).unwrap();
+        let obj = obj_id_or_throw!(&env, self.obj, ());
         match tx.increment(obj, self.key, self.value) {
             Ok(_) => {}
             Err(e) => {

--- a/rust/src/transaction/insert.rs
+++ b/rust/src/transaction/insert.rs
@@ -6,7 +6,11 @@ use jni::{
     sys::{jboolean, jbyteArray, jdouble, jlong, jobject},
 };
 
-use crate::{obj_id::JavaObjId, obj_type::JavaObjType, AUTOMERGE_EXCEPTION};
+use crate::{
+    obj_id::{obj_id_or_throw, JavaObjId},
+    obj_type::JavaObjType,
+    AUTOMERGE_EXCEPTION,
+};
 
 use super::{do_tx_op, TransactionOp};
 
@@ -23,7 +27,7 @@ impl TransactionOp for InsertOp<am::ScalarValue> {
         env: jni::JNIEnv,
         tx: &mut T,
     ) -> Self::Output {
-        let obj = JavaObjId::from_raw(&env, self.obj).unwrap();
+        let obj = obj_id_or_throw!(&env, self.obj, ());
         let idx = match usize::try_from(self.index) {
             Ok(i) => i,
             Err(_) => {
@@ -49,7 +53,7 @@ impl TransactionOp for InsertOp<ObjType> {
         env: jni::JNIEnv,
         tx: &mut T,
     ) -> Self::Output {
-        let obj = JavaObjId::from_raw(&env, self.obj).unwrap();
+        let obj = obj_id_or_throw!(&env, self.obj);
         let idx = match usize::try_from(self.index) {
             Ok(i) => i,
             Err(_) => {

--- a/rust/src/transaction/mark.rs
+++ b/rust/src/transaction/mark.rs
@@ -6,7 +6,11 @@ use jni::{
     sys::{jboolean, jdouble, jlong, jobject, jstring},
 };
 
-use crate::{expand_mark, obj_id::JavaObjId, AUTOMERGE_EXCEPTION};
+use crate::{
+    expand_mark,
+    obj_id::{obj_id_or_throw, JavaObjId},
+    AUTOMERGE_EXCEPTION,
+};
 
 use super::{do_tx_op, TransactionOp};
 
@@ -28,7 +32,7 @@ impl TransactionOp for MarkOp {
         let name_str = JString::from_raw(self.name);
         let name: String = env.get_string(name_str).unwrap().into();
         let mark = am::marks::Mark::new(name, self.value, self.start, self.end);
-        let obj = JavaObjId::from_raw(&env, self.obj).unwrap();
+        let obj = obj_id_or_throw!(&env, self.obj, ());
         match tx.mark(obj, mark, expand) {
             Ok(_) => {}
             Err(e) => {
@@ -315,7 +319,7 @@ impl TransactionOp for Unmark {
         let expand = expand_mark::from_java(&env, expand_obj).unwrap();
         let name_str = JString::from_raw(self.name);
         let name: String = env.get_string(name_str).unwrap().into();
-        let obj = JavaObjId::from_raw(&env, self.obj).unwrap();
+        let obj = obj_id_or_throw!(&env, self.obj, ());
         match tx.unmark(obj, &name, self.start, self.end, expand) {
             Ok(_) => {}
             Err(e) => {

--- a/rust/src/transaction/set.rs
+++ b/rust/src/transaction/set.rs
@@ -7,6 +7,7 @@ use jni::{
     sys::{jbyteArray, jint, jlong, jobject},
 };
 
+use crate::obj_id::obj_id_or_throw;
 use crate::obj_type::JavaObjType;
 use crate::prop::JProp;
 use crate::{obj_id::JavaObjId, AUTOMERGE_EXCEPTION};
@@ -30,7 +31,7 @@ impl<'a, V: Into<automerge::ScalarValue>> TransactionOp for SetOp<'a, V> {
                 return;
             }
         };
-        let obj = JavaObjId::from_raw(&env, self.obj).unwrap();
+        let obj = obj_id_or_throw!(&env, self.obj, ());
 
         match tx.put(obj, key, self.value) {
             Ok(_) => {}
@@ -443,7 +444,7 @@ impl TransactionOp for SetObjOp {
     type Output = jobject;
 
     unsafe fn execute<T: Transactable>(self, env: jni::JNIEnv, tx: &mut T) -> Self::Output {
-        let obj = JavaObjId::from_raw(&env, self.obj).unwrap();
+        let obj = obj_id_or_throw!(&env, self.obj);
         let oid = match tx.put_object(obj, self.key, self.value) {
             Ok(oid) => oid,
             Err(e) => {

--- a/rust/src/transaction/splice.rs
+++ b/rust/src/transaction/splice.rs
@@ -5,7 +5,7 @@ use jni::{
     sys::{jlong, jobject},
 };
 
-use crate::{JavaObjId, AUTOMERGE_EXCEPTION};
+use crate::{obj_id::obj_id_or_throw, JavaObjId, AUTOMERGE_EXCEPTION};
 
 use super::{do_tx_op, TransactionOp};
 
@@ -30,7 +30,7 @@ impl TransactionOp for SpliceOp {
     type Output = ();
 
     unsafe fn execute<T: Transactable>(self, env: jni::JNIEnv, tx: &mut T) -> Self::Output {
-        let obj = JavaObjId::from_raw(&env, self.obj).unwrap();
+        let obj = obj_id_or_throw!(&env, self.obj, ());
         let iter = JObjToValIter {
             jiter: JObject::from_raw(self.values),
             env: &env,

--- a/rust/src/transaction/splice_text.rs
+++ b/rust/src/transaction/splice_text.rs
@@ -4,7 +4,10 @@ use jni::{
     sys::{jlong, jobject},
 };
 
-use crate::{obj_id::JavaObjId, AUTOMERGE_EXCEPTION};
+use crate::{
+    obj_id::{obj_id_or_throw, JavaObjId},
+    AUTOMERGE_EXCEPTION,
+};
 
 use super::{do_tx_op, TransactionOp};
 
@@ -23,7 +26,7 @@ impl<'a> TransactionOp for SpliceTextOp<'a> {
         env: jni::JNIEnv,
         tx: &mut T,
     ) -> Self::Output {
-        let obj = JavaObjId::from_raw(&env, self.obj).unwrap();
+        let obj = obj_id_or_throw!(&env, self.obj, ());
         let value: String = env.get_string(self.value).unwrap().into();
         match tx.splice_text(obj, self.idx as usize, self.delete as isize, &value) {
             Ok(_) => {}


### PR DESCRIPTION
Problem: at various places in the rust codebase we receive an object ID from the java side in the form of a `jobject` which is a pointer to a `ObjectId`. This pointer can be null but we were not checking whether it was null and consequently were panicking and crashing the entire JVM.

Solution: check for null when loading object IDs and throw an IllegalArgumentException if the `ObjectId` is null. This required a macro to avoid lots of code handling the early return.

Fixes #4 (I think)