### PR TITLE
fix incorrect JNI signature for PatchAction.FlagConflict constructor

### DIFF
--- a/rust/src/patches.rs
+++ b/rust/src/patches.rs
@@ -123,7 +123,7 @@ fn to_jni_patch<'a>(
             let jprop = prop_to_java(env, &prop)?;
             env.new_object(
                 FLAG_CONFLICT_CLASS,
-                format!("(L{};J)V", PROP_CLASS),
+                format!("(L{};)V", PROP_CLASS),
                 &[jprop.into(), 0.into()],
             )?
         }


### PR DESCRIPTION
When I do something like the following for an Automerge `Document` object called `_doc`:

```
    PatchLog patchLog = new PatchLog();
    _doc.receiveSyncMessage(_syncState, patchLog, msg);  // uses transactions internally
    for (Patch p : _doc.makePatches(patchLog)) {
           // determine what types of patch we had
    }
```

I get the following panic if there are any `PatchAction.FlagConflict` actions among the patches:
```
stack backtrace:
   0:        0x11759be7b - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h958f6e6821e9b0fb
   1:        0x1175b8073 - core::fmt::write::hb5e3c29742bab55e
   2:        0x11759a65e - std::io::Write::write_fmt::h3f38404afa442946
   3:        0x11759bc59 - std::sys_common::backtrace::print::h1ce04ba6121a0174
   4:        0x11759ce95 - std::panicking::default_hook::{{closure}}::hf2e5fe71523bcace
   5:        0x11759cc14 - std::panicking::default_hook::h4f8cdc98d2dcc8c0
   6:        0x11759d2f3 - std::panicking::rust_panic_with_hook::h28420d44f043d3a5
   7:        0x11759d20e - std::panicking::begin_panic_handler::{{closure}}::h6f886c0e89185cdc
   8:        0x11759c359 - std::sys_common::backtrace::__rust_end_short_backtrace::h7ca2b2ff22d46410
   9:        0x11759cf62 - _rust_begin_unwind
  10:        0x1175cc775 - core::panicking::panic_fmt::h52dad7a658d9bf41
  11:        0x1175ccc15 - core::result::unwrap_failed::h84bbbea2e5d8da9f
  12:        0x117453203 - automerge_jni::patches::to_patch_arraylist::h1da89d0366550522
  13:        0x117468237 - _Java_org_automerge_AutomergeSys_makePatches
fatal runtime error: failed to initiate panic, error 5
Abort trap: 6
```

I believe this PR fixes that problem.  The JNI signature to call the Java `FlagConflict` constructor from Rust was incorrect:  there should only be 1 argument (the `Prop`), not 2.
