### PR TITLE
Handle possible failures when throwing

### DIFF
--- a/rust/src/cursor.rs
+++ b/rust/src/cursor.rs
@@ -5,6 +5,8 @@ use jni::{
     JNIEnv,
 };
 
+use crate::interop::throw_or_fatal;
+
 #[derive(Debug)]
 pub struct Cursor(automerge::Cursor);
 
@@ -80,14 +82,16 @@ pub unsafe extern "C" fn cursorFromString(
     let jstring = &JString::from_raw(s);
     let s = env.get_string(jstring).unwrap();
     let Ok(s) = s.to_str() else {
-        env.throw_new(
+        throw_or_fatal(
+            &mut env,
             "java/lang/IllegalArgumentException",
             "invalid cursor string",
         );
         return JObject::null().into_raw();
     };
     let Ok(cursor) = automerge::Cursor::try_from(s) else {
-        env.throw_new(
+        throw_or_fatal(
+            &mut env,
             "java/lang/IllegalArgumentException",
             "invalid cursor string",
         );
@@ -107,7 +111,11 @@ pub unsafe extern "C" fn cursorFromBytes(
     let bytes = env.convert_byte_array(&jarr).unwrap();
     let Ok(cursor) = automerge::Cursor::try_from(bytes) else {
         // throw IllegalArgumentException
-        env.throw_new("java/lang/IllegalArgumentException", "invalid cursor bytes");
+        throw_or_fatal(
+            &mut env,
+            "java/lang/IllegalArgumentException",
+            "invalid cursor bytes",
+        );
         return JObject::null().into_raw();
     };
     Cursor::from(cursor).into_raw(&mut env).unwrap()

--- a/rust/src/document.rs
+++ b/rust/src/document.rs
@@ -6,9 +6,8 @@ use jni::{
 };
 
 use crate::{
-    interop::{heads_from_jobject, AsPointerObj},
+    interop::{heads_from_jobject, throw_amg_exc_or_fatal, AsPointerObj},
     patches::to_patch_arraylist,
-    AUTOMERGE_EXCEPTION,
 };
 
 #[no_mangle]
@@ -100,7 +99,7 @@ pub unsafe extern "C" fn loadDoc(
     let doc = match automerge::Automerge::load(&bytes) {
         Ok(d) => d,
         Err(e) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+            throw_amg_exc_or_fatal(&mut env, e.to_string());
             return JObject::null().into_raw();
         }
     };
@@ -194,7 +193,7 @@ pub unsafe fn do_fork_at(
     let doc = match doc.fork_at(&heads) {
         Ok(d) => d,
         Err(e) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+            throw_amg_exc_or_fatal(&mut env, e.to_string());
             return JObject::null().into_raw();
         }
     };
@@ -219,7 +218,7 @@ pub unsafe extern "C" fn mergeDoc(
     match doc1.merge(other_doc) {
         Ok(_) => {}
         Err(e) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+            throw_amg_exc_or_fatal(&mut env, e.to_string());
         }
     }
 }
@@ -239,7 +238,7 @@ pub unsafe extern "C" fn mergeDocLogPatches(
     match doc1.merge_and_log_patches(other_doc, patch_log) {
         Ok(_) => {}
         Err(e) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+            throw_amg_exc_or_fatal(&mut env, e.to_string());
         }
     }
 }
@@ -275,7 +274,7 @@ pub unsafe extern "C" fn applyEncodedChanges(
     match doc.load_incremental(&changes_bytes) {
         Ok(_) => {}
         Err(e) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+            throw_amg_exc_or_fatal(&mut env, e.to_string());
         }
     };
 }
@@ -296,7 +295,7 @@ pub unsafe extern "C" fn applyEncodedChangesLogPatches(
     match doc.load_incremental_log_patches(&changes_bytes, patchlog) {
         Ok(_) => {}
         Err(e) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+            throw_amg_exc_or_fatal(&mut env, e.to_string());
         }
     };
 }

--- a/rust/src/interop.rs
+++ b/rust/src/interop.rs
@@ -3,8 +3,9 @@ use automerge::{self as am, transaction::Transaction, ChangeHash};
 use jni::{
     objects::{JObject, JObjectArray, JPrimitiveArray, JValue},
     sys::{jbyteArray, jobject},
-    JNIEnv,
 };
+
+use crate::AUTOMERGE_EXCEPTION;
 
 pub(crate) const CHANGEHASH_CLASS: &str = am_classname!("ChangeHash");
 
@@ -143,4 +144,19 @@ pub(crate) fn changehash_to_jobject<'local>(
     env.set_field(&jhash, "hash", "[B", (&byte_array).into())
         .unwrap();
     Ok(jhash)
+}
+
+pub(crate) fn throw_amg_exc_or_fatal<S: AsRef<str>>(env: &mut jni::JNIEnv, msg: S) {
+    throw_or_fatal(env, AUTOMERGE_EXCEPTION, msg);
+}
+
+pub(crate) fn throw_or_fatal<S: AsRef<str>>(
+    env: &mut jni::JNIEnv,
+    exc_class: &'static str,
+    msg: S,
+) {
+    if env.throw_new(exc_class, msg.as_ref()).is_err() {
+        eprintln!("Failed to throw exception: {}", msg.as_ref());
+        env.fatal_error(format!("Failed to throw exception: {}", msg.as_ref()));
+    }
 }

--- a/rust/src/java_option.rs
+++ b/rust/src/java_option.rs
@@ -1,7 +1,4 @@
-use jni::{
-    objects::{JObject, JValue},
-    JNIEnv,
-};
+use jni::objects::{JObject, JValue};
 
 pub(crate) fn make_optional<'a>(
     env: &mut jni::JNIEnv<'a>,
@@ -21,20 +18,4 @@ pub(crate) fn make_empty_option<'a>(
 ) -> Result<JObject<'a>, jni::errors::Error> {
     env.call_static_method("java/util/Optional", "empty", "()Ljava/util/Optional;", &[])?
         .l()
-}
-
-pub(crate) fn make_optional_of<'local, T, F>(
-    env: &mut JNIEnv<'local>,
-    opt: &Option<T>,
-    func: F,
-) -> Result<JObject<'local>, jni::errors::Error>
-where
-    F: for<'a> FnOnce(&mut JNIEnv<'a>, &T) -> Result<JObject<'a>, jni::errors::Error>,
-{
-    if let Some(val) = opt {
-        let val_obj = func(env, val)?;
-        make_optional(env, (&val_obj).into())
-    } else {
-        make_empty_option(env)
-    }
 }

--- a/rust/src/obj_id.rs
+++ b/rust/src/obj_id.rs
@@ -96,7 +96,8 @@ macro_rules! obj_id_or_throw {
         match JavaObjId::from_raw($env, $obj_id) {
             Ok(Some(id)) => id,
             Ok(None) => {
-                $env.throw_new(
+                crate::interop::throw_or_fatal(
+                    $env,
                     "java/lang/IllegalArgumentException",
                     "Object ID cannot be null",
                 );
@@ -104,8 +105,7 @@ macro_rules! obj_id_or_throw {
                 return $returning;
             }
             Err(e) => {
-                use crate::AUTOMERGE_EXCEPTION;
-                $env.throw_new(AUTOMERGE_EXCEPTION, format!("{}", e));
+                crate::interop::throw_amg_exc_or_fatal($env, e.to_string());
                 #[allow(clippy::unused_unit)]
                 return $returning;
             }
@@ -113,6 +113,8 @@ macro_rules! obj_id_or_throw {
     };
 }
 pub(crate) use obj_id_or_throw;
+
+use crate::interop::throw_or_fatal;
 
 #[no_mangle]
 #[jni_fn]
@@ -174,7 +176,8 @@ pub unsafe extern "C" fn objectIdsEqual(
     let right = JavaObjId::from_raw(&mut env, right).unwrap();
     match (left, right) {
         (None, _) | (_, None) => {
-            env.throw_new(
+            throw_or_fatal(
+                &mut env,
                 "java/lang/IllegalArgumentException",
                 "Object ID cannot be null",
             );

--- a/rust/src/read_methods.rs
+++ b/rust/src/read_methods.rs
@@ -7,13 +7,14 @@ use jni::sys::{jint, jlong, jobject};
 use crate::am_value::{scalar_to_amvalue, to_amvalue, to_optional_amvalue};
 use crate::conflicts::make_optional_conflicts;
 use crate::cursor::Cursor;
-use crate::interop::{changehash_to_jobject, heads_from_jobject, CHANGEHASH_CLASS};
+use crate::interop::{
+    changehash_to_jobject, heads_from_jobject, throw_amg_exc_or_fatal, CHANGEHASH_CLASS,
+};
 use crate::java_option::{make_empty_option, make_optional};
 use crate::mark::mark_to_java;
 use crate::obj_id::{obj_id_or_throw, JavaObjId};
 use crate::obj_type::JavaObjType;
 use crate::prop::JProp;
-use crate::AUTOMERGE_EXCEPTION;
 use crate::{interop::AsPointerObj, read_ops::ReadOps};
 use automerge as am;
 use automerge::transaction::Transaction as AmTransaction;
@@ -35,7 +36,7 @@ macro_rules! catch {
         match $e {
             Ok(r) => r,
             Err(e) => {
-                $env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                crate::interop::throw_amg_exc_or_fatal(&mut $env, e.to_string());
                 return JObject::null().into_raw();
             }
         }
@@ -127,7 +128,7 @@ impl SomeReadPointer {
             Ok(Some(c)) => make_optional(&mut env, (&c).into()).unwrap().into_raw(),
             Ok(None) => make_empty_option(&mut env).unwrap().into_raw(),
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(&mut env, e.to_string());
                 JObject::null().into_raw()
             }
         }
@@ -164,7 +165,7 @@ impl SomeReadPointer {
             },
             Ok(_) => return make_empty_option(env).unwrap().into_raw(),
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(env, e.to_string());
                 return JObject::null().into_raw();
             }
         };
@@ -215,7 +216,7 @@ impl SomeReadPointer {
                 return make_empty_option(&mut env).unwrap().into_raw()
             }
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(&mut env, e.to_string());
                 return JObject::null().into_raw();
             }
         };
@@ -258,7 +259,7 @@ impl SomeReadPointer {
                 return make_empty_option(&mut env).unwrap().into_raw()
             }
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(&mut env, e.to_string());
                 return JObject::null().into_raw();
             }
         };
@@ -314,7 +315,7 @@ impl SomeReadPointer {
                 return make_empty_option(&mut env).unwrap().into_raw()
             }
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(&mut env, e.to_string());
                 return JObject::null().into_raw();
             }
         };
@@ -340,7 +341,7 @@ impl SomeReadPointer {
         let marks = match marks {
             Ok(m) => m,
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(&mut env, e.to_string());
                 return JObject::null().into_raw();
             }
         };
@@ -376,7 +377,7 @@ impl SomeReadPointer {
         let marks = match marks {
             Ok(m) => m,
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(&mut env, e.to_string());
                 return JObject::null().into_raw();
             }
         };
@@ -406,14 +407,14 @@ impl SomeReadPointer {
         let heads = maybe_heads(&mut env, maybe_heads_pointer).unwrap();
         let read = SomeRead::from_pointer(&mut env, self);
         if index < 0 {
-            env.throw_new(AUTOMERGE_EXCEPTION, "Index must be >= 0");
+            throw_amg_exc_or_fatal(&mut env, "Index must be >= 0");
             return JObject::null().into_raw();
         }
         let cursor = read.get_cursor(obj, index as usize, heads.as_deref());
         let cursor = match cursor {
             Ok(c) => c,
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(&mut env, e.to_string());
                 return JObject::null().into_raw();
             }
         };
@@ -436,7 +437,7 @@ impl SomeReadPointer {
         let index = match index {
             Ok(i) => i,
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(&mut env, e.to_string());
                 return 0;
             }
         };
@@ -452,7 +453,7 @@ impl SomeReadPointer {
                 return make_empty_option(&mut env).unwrap().into_raw();
             }
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(&mut env, e.to_string());
                 return JObject::null().into_raw();
             }
         };

--- a/rust/src/sync.rs
+++ b/rust/src/sync.rs
@@ -10,9 +10,8 @@ use jni::{
 };
 
 use crate::{
-    interop::{changehash_to_jobject, AsPointerObj, CHANGEHASH_CLASS},
+    interop::{changehash_to_jobject, throw_amg_exc_or_fatal, AsPointerObj, CHANGEHASH_CLASS},
     java_option::{make_empty_option, make_optional},
-    AUTOMERGE_EXCEPTION,
 };
 
 #[no_mangle]
@@ -60,14 +59,14 @@ pub unsafe extern "C" fn receiveSyncMessage(
     let message = match Message::decode(&message_bytes) {
         Ok(m) => m,
         Err(e) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+            throw_amg_exc_or_fatal(&mut env, e.to_string());
             return;
         }
     };
     match doc.receive_sync_message(state, message) {
         Ok(()) => {}
         Err(e) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+            throw_amg_exc_or_fatal(&mut env, e.to_string());
         }
     }
 }
@@ -90,14 +89,14 @@ pub unsafe extern "C" fn receiveSyncMessageLogPatches(
     let message = match Message::decode(&message_bytes) {
         Ok(m) => m,
         Err(e) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+            throw_amg_exc_or_fatal(&mut env, e.to_string());
             return;
         }
     };
     match doc.receive_sync_message_log_patches(state, message, patch_log) {
         Ok(_) => {}
         Err(e) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+            throw_amg_exc_or_fatal(&mut env, e.to_string());
         }
     }
 }
@@ -128,7 +127,7 @@ pub unsafe extern "C" fn decodeSyncState(
     match SyncState::decode(&bytes) {
         Ok(state) => state.to_pointer_obj(&mut env).unwrap().into_raw(),
         Err(e) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+            throw_amg_exc_or_fatal(&mut env, e.to_string());
             JObject::null().into_raw()
         }
     }

--- a/rust/src/transaction.rs
+++ b/rust/src/transaction.rs
@@ -1,7 +1,7 @@
 use am::transaction::Transactable;
 use automerge as am;
 use automerge_jni_macros::jni_fn;
-use jni::{objects::JObject, sys::jobject};
+use jni::sys::jobject;
 
 use crate::{
     interop::{changehash_to_jobject, AsPointerObj},
@@ -115,12 +115,4 @@ pub unsafe extern "C" fn rollbackTransaction(
     tx_pointer: jobject,
 ) {
     do_owned_tx_op(&mut env, tx_pointer, Rollback);
-}
-
-#[derive(Debug, thiserror::Error)]
-enum OpError {
-    #[error(transparent)]
-    Automerge(#[from] am::AutomergeError),
-    #[error(transparent)]
-    Jni(#[from] jni::errors::Error),
 }

--- a/rust/src/transaction/delete.rs
+++ b/rust/src/transaction/delete.rs
@@ -6,8 +6,8 @@ use jni::{
 };
 
 use crate::{
+    interop::throw_amg_exc_or_fatal,
     obj_id::{obj_id_or_throw, JavaObjId},
-    AUTOMERGE_EXCEPTION,
 };
 
 use super::{do_tx_op, TransactionOp};
@@ -25,7 +25,7 @@ impl TransactionOp for DeleteOp {
         match tx.delete(obj, self.key) {
             Ok(_) => {}
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(env, e.to_string());
             }
         }
     }
@@ -64,7 +64,7 @@ pub unsafe extern "C" fn deleteInList<'local>(
     let idx = match usize::try_from(idx) {
         Ok(idx) => idx,
         Err(_) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, "Index out of bounds");
+            throw_amg_exc_or_fatal(&mut env, "Index out of bounds");
             return;
         }
     };

--- a/rust/src/transaction/increment.rs
+++ b/rust/src/transaction/increment.rs
@@ -5,8 +5,8 @@ use jni::{
 };
 
 use crate::{
+    interop::throw_amg_exc_or_fatal,
     obj_id::{obj_id_or_throw, JavaObjId},
-    AUTOMERGE_EXCEPTION,
 };
 
 use super::{do_tx_op, TransactionOp};
@@ -29,7 +29,7 @@ impl TransactionOp for IncrementOp {
         match tx.increment(obj, self.key, self.value) {
             Ok(_) => {}
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(env, e.to_string());
             }
         }
     }
@@ -71,7 +71,7 @@ pub unsafe extern "C" fn incrementInList(
     let idx = match usize::try_from(idx) {
         Ok(i) => i,
         Err(_) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, "index cannot be negative");
+            throw_amg_exc_or_fatal(&mut env, "index cannot be negative");
             return;
         }
     };

--- a/rust/src/transaction/insert.rs
+++ b/rust/src/transaction/insert.rs
@@ -7,9 +7,9 @@ use jni::{
 };
 
 use crate::{
+    interop::throw_amg_exc_or_fatal,
     obj_id::{obj_id_or_throw, JavaObjId},
     obj_type::JavaObjType,
-    AUTOMERGE_EXCEPTION,
 };
 
 use super::{do_tx_op, TransactionOp};
@@ -31,14 +31,14 @@ impl TransactionOp for InsertOp<am::ScalarValue> {
         let idx = match usize::try_from(self.index) {
             Ok(i) => i,
             Err(_) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, "index cannot be negative");
+                throw_amg_exc_or_fatal(env, "index cannot be negative");
                 return;
             }
         };
         match tx.insert(obj, idx, self.value) {
             Ok(_) => {}
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(env, e.to_string());
             }
         }
     }
@@ -56,14 +56,14 @@ impl TransactionOp for InsertOp<ObjType> {
         let idx = match usize::try_from(self.index) {
             Ok(i) => i,
             Err(_) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, "index cannot be negative");
+                throw_amg_exc_or_fatal(env, "index cannot be negative");
                 return JObject::null().into_raw();
             }
         };
         let value = match tx.insert_object(obj, idx, self.value) {
             Ok(v) => v,
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(env, e.to_string());
                 return JObject::null().into_raw();
             }
         };
@@ -149,7 +149,7 @@ pub unsafe extern "C" fn insertUintInList(
     let int = match u64::try_from(value) {
         Ok(i) => i,
         Err(_) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, "uint value must not be negative");
+            throw_amg_exc_or_fatal(&mut env, "uint value must not be negative");
             return;
         }
     };

--- a/rust/src/transaction/mark.rs
+++ b/rust/src/transaction/mark.rs
@@ -8,8 +8,8 @@ use jni::{
 
 use crate::{
     expand_mark,
+    interop::throw_amg_exc_or_fatal,
     obj_id::{obj_id_or_throw, JavaObjId},
-    AUTOMERGE_EXCEPTION,
 };
 
 use super::{do_tx_op, TransactionOp};
@@ -37,7 +37,7 @@ impl TransactionOp for MarkOp {
             Ok(_) => {}
             Err(e) => {
                 let msg = format!("Error marking: {e}");
-                env.throw_new(AUTOMERGE_EXCEPTION, msg);
+                throw_amg_exc_or_fatal(env, msg);
             }
         }
     }
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn markUint(
     let int = match u64::try_from(value) {
         Ok(i) => am::ScalarValue::Uint(i),
         Err(_) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, "uint value must not be negative");
+            throw_amg_exc_or_fatal(&mut env, "uint value must not be negative");
             return;
         }
     };
@@ -324,7 +324,7 @@ impl TransactionOp for Unmark {
             Ok(_) => {}
             Err(e) => {
                 let msg = format!("Error marking: {e}");
-                env.throw_new(AUTOMERGE_EXCEPTION, msg);
+                throw_amg_exc_or_fatal(env, msg);
             }
         }
     }

--- a/rust/src/transaction/set.rs
+++ b/rust/src/transaction/set.rs
@@ -8,10 +8,11 @@ use jni::{
     sys::{jbyteArray, jint, jlong, jobject},
 };
 
+use crate::interop::throw_amg_exc_or_fatal;
 use crate::obj_id::obj_id_or_throw;
+use crate::obj_id::JavaObjId;
 use crate::obj_type::JavaObjType;
 use crate::prop::JProp;
-use crate::{obj_id::JavaObjId, AUTOMERGE_EXCEPTION};
 
 use super::{do_tx_op, TransactionOp};
 
@@ -28,7 +29,7 @@ impl<'a, V: Into<automerge::ScalarValue>> TransactionOp for SetOp<'a, V> {
         let key = match self.prop.try_into_prop(env) {
             Ok(k) => k,
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(env, e.to_string());
                 return;
             }
         };
@@ -37,7 +38,7 @@ impl<'a, V: Into<automerge::ScalarValue>> TransactionOp for SetOp<'a, V> {
         match tx.put(obj, key, self.value) {
             Ok(_) => {}
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(env, e.to_string());
             }
         }
     }
@@ -453,7 +454,7 @@ impl TransactionOp for SetObjOp {
         let oid = match tx.put_object(obj, self.key, self.value) {
             Ok(oid) => oid,
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(env, e.to_string());
                 return JObject::null().into_raw();
             }
         };
@@ -501,7 +502,7 @@ pub unsafe extern "C" fn setObjectInList(
     let idx = match usize::try_from(idx) {
         Ok(idx) => idx,
         Err(_) => {
-            env.throw_new(AUTOMERGE_EXCEPTION, "index must be non-negative");
+            throw_amg_exc_or_fatal(&mut env, "index must be non-negative");
             return JObject::null().into_raw();
         }
     };

--- a/rust/src/transaction/splice.rs
+++ b/rust/src/transaction/splice.rs
@@ -5,7 +5,9 @@ use jni::{
     sys::{jlong, jobject},
 };
 
-use crate::{obj_id::obj_id_or_throw, JavaObjId, AUTOMERGE_EXCEPTION};
+use crate::{
+    interop::throw_amg_exc_or_fatal, obj_id::obj_id_or_throw, JavaObjId, AUTOMERGE_EXCEPTION,
+};
 
 use super::{do_tx_op, TransactionOp};
 
@@ -38,7 +40,7 @@ impl TransactionOp for SpliceOp {
         match tx.splice(obj, self.index, self.delete, iter) {
             Ok(_) => {}
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(env, e.to_string());
             }
         }
     }

--- a/rust/src/transaction/splice_text.rs
+++ b/rust/src/transaction/splice_text.rs
@@ -5,8 +5,8 @@ use jni::{
 };
 
 use crate::{
+    interop::throw_amg_exc_or_fatal,
     obj_id::{obj_id_or_throw, JavaObjId},
-    AUTOMERGE_EXCEPTION,
 };
 
 use super::{do_tx_op, TransactionOp};
@@ -31,7 +31,7 @@ impl<'a> TransactionOp for SpliceTextOp<'a> {
         match tx.splice_text(obj, self.idx as usize, self.delete as isize, &value) {
             Ok(_) => {}
             Err(e) => {
-                env.throw_new(AUTOMERGE_EXCEPTION, e.to_string());
+                throw_amg_exc_or_fatal(env, e.to_string());
             }
         }
     }


### PR DESCRIPTION
In quite a few places throughout the codebase we call `JNIEnv::throw_new` and ignore the `Result<_, _>` which is returned. This can lead to difficult to debug errors where the JVM is left in a broken state when we return from FFI. This commit updates all these code paths to catch the error and throw JNIEnv::fatal_error, which aborts the JVM.